### PR TITLE
Add single-attempt timed retry to CSRF token fetch

### DIFF
--- a/Newmode/__init__.py
+++ b/Newmode/__init__.py
@@ -2,6 +2,7 @@ from requests import request
 import os
 import json
 import logging
+import time
 
 logger = logging.getLogger(__name__)
 
@@ -57,12 +58,15 @@ class Client(object):
 
         return response
 
-    def getCSRFToken(self):
+    def getCSRFToken(self, stage=1):
         response = self.baseRequest('session/token', 'GET', {}, False, False)
         if (response.status_code == 200):
             data = response.json()
             return data['X-CSRF-Token']
-        else:
+        elif stage == 1:
+            time.sleep(1)
+            return self.getCSRFToken(stage=2)
+        elif stage == 2:
             logging.warning("Error getting CSRF Token")
 
         return None


### PR DESCRIPTION
Hey y'all, apologies for the unsolicited PR.

I have an email out to some New/Mode folks (Ben and Mikey, specifically) about an issue we've been having at TMC where the API doesn't always fetch a CSRF token correctly when doing rapid-fire calls. We're waiting to hear back, and I'm happy to close this PR if the issue turns out to be something on our end, but I thought it might be helpful to build a single-time retry logic into the CSRF token fetch in order to avoid the problems we're seeing in practice.

Let me know if I can clarify the intent here, or expand on what's happening unexpectedly when the existing code is in use here at TMC.